### PR TITLE
Reduce spurious hash changes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -22,6 +22,6 @@ let
         super.callPackage (sources.reflex-dom-template.outPath) {};
     };
   };
-  drv = haskellPackages.callPackage ./workshop.nix {};
+  drv = haskellPackages.callPackage ./workshop.nix { newNixpkgs = import sources.nixpkgs {}; };
 in
   drv

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -11,6 +11,18 @@
         "url": "https://github.com/nmattia/niv/archive/82e5cd1ad3c387863f0545d7591512e76ab0fc41.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "nixpkgs": {
+        "branch": "nixos-23.05",
+        "description": "Nix Packages collection & NixOS",
+        "homepage": "",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ea5234e7073d5f44728c499192544a84244bf35a",
+        "sha256": "1iqfglh1fdgqxm7n4763k1cipna68sa0cb3azm2gdzhr374avcvk",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/ea5234e7073d5f44728c499192544a84244bf35a.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "reflex-dom-contrib": {
         "branch": "master",
         "description": null,

--- a/vm.nix
+++ b/vm.nix
@@ -1,19 +1,16 @@
 let
   sources = import ./nix/sources.nix {};
+  newNixpkgs = import sources.nixpkgs {};
   reflex-platform = import sources.reflex-platform {};
   inherit (reflex-platform) nixpkgs;
   inherit (nixpkgs) pkgs;
 
   workshop-pkg = import ./. {};
   reflex-workshop-assets = import ./content {};
-  reflex-workshop = pkgs.stdenv.mkDerivation {
+  reflex-workshop = newNixpkgs.lib.cleanSourceWith {
+    src = ./.;
     name = "reflex-workshop-source";
-    src = pkgs.lib.cleanSource ./.;
-    phases = ["installPhase"];
-    installPhase = ''
-      mkdir $out
-      cp -r $src/* $out/
-    '';
+    filter = newNixpkgs.lib.cleanSourceFilter;
   };
 
   tools = with pkgs; [

--- a/workshop.nix
+++ b/workshop.nix
@@ -1,5 +1,5 @@
-{ mkDerivation, pkgs, aeson, base, bytestring, containers, dependent-map
-, dependent-sum, errors, exception-transformers, filepath
+{ mkDerivation, newNixpkgs, aeson, base, bytestring, containers
+, dependent-map, dependent-sum, errors, exception-transformers, filepath
 , ghcjs-dom, jsaddle, jsaddle-warp, lens, mtl, ref-tf, reflex
 , reflex-dom, reflex-dom-contrib, reflex-dom-nested-routing
 , reflex-dom-storage, reflex-dom-template, stdenv, text
@@ -8,7 +8,11 @@
 mkDerivation {
   pname = "workshop";
   version = "0.1";
-  src = pkgs.lib.cleanSource ./.;
+  src = newNixpkgs.lib.cleanSourceWith {
+    src = ./.;
+    name = "reflex-workshop-source";
+    filter = newNixpkgs.lib.cleanSourceFilter;
+  };
   libraryHaskellDepends = [
     aeson base bytestring containers dependent-map dependent-sum errors
     exception-transformers filepath ghcjs-dom jsaddle jsaddle-warp lens

--- a/workshop.nix
+++ b/workshop.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, aeson, base, bytestring, containers, dependent-map
+{ mkDerivation, pkgs, aeson, base, bytestring, containers, dependent-map
 , dependent-sum, errors, exception-transformers, filepath
 , ghcjs-dom, jsaddle, jsaddle-warp, lens, mtl, ref-tf, reflex
 , reflex-dom, reflex-dom-contrib, reflex-dom-nested-routing
@@ -8,7 +8,7 @@
 mkDerivation {
   pname = "workshop";
   version = "0.1";
-  src = ./.;
+  src = pkgs.lib.cleanSource ./.;
   libraryHaskellDepends = [
     aeson base bytestring containers dependent-map dependent-sum errors
     exception-transformers filepath ghcjs-dom jsaddle jsaddle-warp lens


### PR DESCRIPTION
These commits insulate the repo against changes to the output hashes due to:

- The user's NIX_PATH
- The directory name of the user's clone of the git repo
- The internals of the .git directory

These changes are necessary to ensure that users have a high chance of being able to retrieve the finished build products from cache without a large rebuild.